### PR TITLE
fix f-string syntax error in fn_report.report

### DIFF
--- a/symbll.py
+++ b/symbll.py
@@ -303,7 +303,7 @@ class fn_report(FuncClass):
             last = state
         else:
             last = a[-1]
-        print(f"report: ({" ".join(map(str, reversed(a)))})")
+        print(f"report: ({' '.join(map(str, reversed(a)))})")
         return last.bumpref()
 
     @classmethod


### PR DESCRIPTION
Without this change, starting up bllsh fails on my machine:

```
$ python3 -VV
Python 3.11.10 (main, Sep 12 2024, 08:19:28) [Clang 16.0.6 ]
$ python3 ./bllsh
Traceback (most recent call last):
  File "/home/thestack/bllsh/./bllsh", line 21, in <module>
    import symbll
  File "/home/thestack/bllsh/symbll.py", line 306
    print(f"report: ({" ".join(map(str, reversed(a)))})")
                                                        ^
SyntaxError: f-string: expecting '}'
```
(Maybe later Python versions allow using the same quoting both for the f-string and within its curly brace expressions? 🤔 )